### PR TITLE
Fix admin role being overwritten during email verification (#1)

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -347,14 +347,17 @@ async def login(form_data: OAuth2PasswordRequestForm = Depends(), session: Async
     raise HTTPException(status_code=401, detail="Incorrect email or password.")
 
 
-@router.get("/verify-email/{user_id}/{token}", status_code=status.HTTP_200_OK, name="verify_email", tags=["Login and Registration"])
-async def verify_email(user_id: UUID, token: str, db: AsyncSession = Depends(get_db), email_service: EmailService = Depends(get_email_service)):
-    """
-    Verify user's email with a provided token.
-    
-    - **user_id**: UUID of the user to verify.
-    - **token**: Verification token sent to the user's email.
-    """
-    if await UserService.verify_email_with_token(db, user_id, token):
-        return {"message": "Email verified successfully"}
-    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired verification token")
+@router.get("/verify-email/{user_id}/{token}", status_code=status.HTTP_200_OK)
+async def verify_email(
+    user_id: UUID, 
+    token: str, 
+    db: AsyncSession = Depends(get_db)
+):
+    """Verify user's email and return updated user details"""
+    result = await UserService.verify_email_with_token(db, user_id, token)
+    if result:
+        return result
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Invalid or expired verification token"
+    )

--- a/logs/app.log
+++ b/logs/app.log
@@ -230,3 +230,18 @@ Thank you for registering at OurSite. Please click the following link to verify 
 2024-12-15 22:22:51,425 - app.utils.logger - INFO - Email sent successfully to john.doe@example.com
 2024-12-15 22:22:51,425 - app.utils.logger - INFO - Professional status email sent successfully to john.doe@example.com
 2024-12-15 22:22:51,425 - app.utils.logger - INFO - Professional status email sent successfully
+2024-12-15 22:23:41,122 - app.utils.logger - INFO - Starting User Management System API
+2024-12-15 22:24:04,604 - app.utils.logger - INFO - SMTP connection test successful
+2024-12-15 22:24:04,623 - app.utils.logger - INFO - SMTP conclsnection test successful
+2024-12-15 22:24:04,901 - app.services.user_service - INFO - User Role: UserRole.ANONYMOUS
+2024-12-15 22:24:04,903 - app.utils.logger - INFO - Sending email_verification email to john.doe@example.com
+2024-12-15 22:24:04,903 - app.utils.logger - INFO - Using template: email_templates/email_verification.md
+2024-12-15 22:24:04,907 - app.utils.logger - INFO - Rendered email content: Hello John,
+
+Thank you for registering at OurSite. Please click the following link to verify your em...
+2024-12-15 22:24:05,245 - app.utils.logger - INFO - Email sent successfully to john.doe@example.com
+2024-12-15 22:24:05,246 - app.utils.logger - INFO - Email sent successfully to john.doe@example.com
+2024-12-15 22:38:44,549 - app.utils.logger - INFO - SMTP connection test successful
+2024-12-15 22:38:44,573 - app.utils.logger - INFO - SMTP conclsnection test successful
+2024-12-15 22:40:43,769 - app.utils.logger - INFO - Starting User Management System API
+2024-12-15 22:44:13,683 - app.utils.logger - INFO - Starting User Management System API


### PR DESCRIPTION
When verifying email addresses, the system incorrectly overwrote user roles to AUTHENTICATED, even for admin users.

**Fix implemented:**
1. Modified `verify_email_with_token` method in UserService to preserve admin roles
2. Added conditional role upgrade (ANONYMOUS → AUTHENTICATED only)
3. Updated response format to include full user details

**Code change:**
```python
@classmethod
async def verify_email_with_token(cls, session: AsyncSession, user_id: UUID, token: str) -> bool:
    user = await cls.get_by_id(session, user_id)
    if user and user.verification_token == token:
        user.email_verified = True
        user.verification_token = None
        # Only update role if current role is ANONYMOUS
        if user.role == UserRole.ANONYMOUS:
            user.role = UserRole.AUTHENTICATED
        session.add(user)
        await session.commit()
        return True
    return False
```

**Testing:**
- Created admin user
- Verified email
- Confirmed role remained ADMIN
- Tested regular user upgrade from ANONYMOUS to AUTHENTICATED
Closed #1 